### PR TITLE
docs: 添加 `PROXY` policy 配置举例

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,45 @@ rules:
   - MATCH,DIRECT
 ```
 
+#### `PROXY` policy 配置举例
+
+vmess:
+
+```yaml
+proxies:
+  - name: "PROXY"
+    type: vmess
+    server: server
+    port: 443
+    uuid: uuid
+    alterId: 32
+    cipher: auto
+    # udp: true
+    # tls: true
+    # skip-cert-verify: true
+    # servername: example.com # priority over wss host
+    # network: ws
+    # ws-opts:
+    #   path: /path
+    #   headers:
+    #     Host: v2ray.com
+    #   max-early-data: 2048
+    #   early-data-header-name: Sec-WebSocket-Protocol
+```
+
+Shadowsocks:
+
+```yaml
+proxies:
+  - name: "PROXY"
+    type: ss
+    server: server
+    port: 443
+    cipher: chacha20-ietf-poly1305
+    password: "password"
+    # udp: true
+```
+
 ## 激赏 | Donation
 
 - **比特币（BTC）bech32 地址**：bc1qfe4nxcanet4w4ph8pf6qqyf263y68vw26nv9j9


### PR DESCRIPTION
添加原因：不熟悉 ClashX 的新用户在复制 `rule-providers` 和 `rules` 到自己的配置中后很容易忘记配置 proxies 导致报错 `rules[8] [RULE-SET,proxy,PROXY] error: proxy [PROXY] not found` 