### PR TITLE
fix: apple maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ rules:
   - RULE-SET,applications,DIRECT
   - DOMAIN,clash.razord.top,DIRECT
   - DOMAIN,yacd.haishan.me,DIRECT
+  - DOMAIN,gspe1-ssl.ls.apple.com,DIRECT
   - RULE-SET,private,DIRECT
   - RULE-SET,reject,REJECT
   - RULE-SET,icloud,DIRECT


### PR DESCRIPTION
Apple Maps first requests `https://gspe1-ssl.ls.apple.com/pep/gcc` to get current region. Connect to `gspe1-ssl.ls.apple.com` directly to use the correct maps (e.g. maps provided by [amap.com](https://www.amap.com/) in CN).

https://github.com/felixonmars/dnsmasq-china-list/pull/457#issuecomment-1467871060