### PR TITLE
Fix: the incorrect order in which the rules are applied in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,21 +177,21 @@ rule-providers:
 
 ```yaml
 rules:
+  - RULE-SET,reject,REJECT
   - RULE-SET,applications,DIRECT
   - DOMAIN,clash.razord.top,DIRECT
   - DOMAIN,yacd.haishan.me,DIRECT
   - RULE-SET,private,DIRECT
-  - RULE-SET,reject,REJECT
   - RULE-SET,icloud,DIRECT
   - RULE-SET,apple,DIRECT
-  - RULE-SET,google,PROXY
-  - RULE-SET,proxy,PROXY
   - RULE-SET,direct,DIRECT
   - RULE-SET,lancidr,DIRECT
   - RULE-SET,cncidr,DIRECT
-  - RULE-SET,telegramcidr,PROXY
   - GEOIP,LAN,DIRECT
   - GEOIP,CN,DIRECT
+  - RULE-SET,google,PROXY
+  - RULE-SET,proxy,PROXY
+  - RULE-SET,telegramcidr,PROXY
   - MATCH,PROXY
 ```
 
@@ -202,11 +202,11 @@ rules:
 
 ```yaml
 rules:
+  - RULE-SET,reject,REJECT
   - RULE-SET,applications,DIRECT
   - DOMAIN,clash.razord.top,DIRECT
   - DOMAIN,yacd.haishan.me,DIRECT
   - RULE-SET,private,DIRECT
-  - RULE-SET,reject,REJECT
   - RULE-SET,tld-not-cn,PROXY
   - RULE-SET,gfw,PROXY
   - RULE-SET,telegramcidr,PROXY


### PR DESCRIPTION
Refer to #381.

---

分流规则，应先 `REJECT` 规则中提到的，再 `DIRECT` 规则中提到的，再 `PROXY` 规则中提到的，最后再黑白名单模式控制规则外的内容。

如果 `REJECT` 的规则在 `DIRECT` 或 `PROXY` 之下，那效果就会降低。

如 #380 的问题，`DIRECT` 规则集 `direct` 中有 `cn.bing.com`，但 `PROXY` 规则集 `proxy` 中有 `+.bing.com`。而 `proxy` 在 `direct` 之上，导致白名单中的直连域名被代理。

---

白名单模式规则建议从：

> ``` yaml
> rules:
>   - RULE-SET,applications,DIRECT
>   - DOMAIN,clash.razord.top,DIRECT
>   - DOMAIN,yacd.haishan.me,DIRECT
>   - RULE-SET,private,DIRECT
>   - RULE-SET,reject,REJECT
>   - RULE-SET,icloud,DIRECT
>   - RULE-SET,apple,DIRECT
>   - RULE-SET,google,PROXY
>   - RULE-SET,proxy,PROXY
>   - RULE-SET,direct,DIRECT
>   - RULE-SET,lancidr,DIRECT
>   - RULE-SET,cncidr,DIRECT
>   - RULE-SET,telegramcidr,PROXY
>   - GEOIP,LAN,DIRECT
>   - GEOIP,CN,DIRECT
>   - MATCH,PROXY
> ```

改为：

``` yaml
rules:
  - RULE-SET,reject,REJECT
  - RULE-SET,applications,DIRECT
  - DOMAIN,clash.razord.top,DIRECT
  - DOMAIN,yacd.haishan.me,DIRECT
  - RULE-SET,private,DIRECT
  - RULE-SET,icloud,DIRECT
  - RULE-SET,apple,DIRECT
  - RULE-SET,direct,DIRECT
  - RULE-SET,lancidr,DIRECT
  - RULE-SET,cncidr,DIRECT
  - GEOIP,LAN,DIRECT
  - GEOIP,CN,DIRECT
  - RULE-SET,google,PROXY
  - RULE-SET,proxy,PROXY
  - RULE-SET,telegramcidr,PROXY
  - MATCH,PROXY
```

---

黑名单模式规则建议从：

> ``` yaml
> rules:
>   - RULE-SET,applications,DIRECT
>   - DOMAIN,clash.razord.top,DIRECT
>   - DOMAIN,yacd.haishan.me,DIRECT
>   - RULE-SET,private,DIRECT
>   - RULE-SET,reject,REJECT
>   - RULE-SET,tld-not-cn,PROXY
>   - RULE-SET,gfw,PROXY
>   - RULE-SET,telegramcidr,PROXY
>   - MATCH,DIRECT
> ```

改为：

``` yaml
rules:
  - RULE-SET,reject,REJECT
  - RULE-SET,applications,DIRECT
  - DOMAIN,clash.razord.top,DIRECT
  - DOMAIN,yacd.haishan.me,DIRECT
  - RULE-SET,private,DIRECT
  - RULE-SET,tld-not-cn,PROXY
  - RULE-SET,gfw,PROXY
  - RULE-SET,telegramcidr,PROXY
  - MATCH,DIRECT
```

---

如果担心 `REJECT` 的规则太强了，也可以把 `REJECT` 放倒数第 2 行。前提是 `REJECT` 规则范围与 `DIRECT` 或 `PROXY` 有重合，且应用范围大于后者 (`+.bing.com` > `cn.bing.con`)，否则不会有冲突。

---

规则的应用范围，是 `REJECT` < `DIRECT` < `PROXY` < `MATCH`（其他）。放置的顺序也应如此。否则小的被大的包含，根本应用不上。