### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -8,6 +8,8 @@ on:
       - master
     paths-ignore:
       - "**/README.md"
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Loyalsoldier/clash-rules/security/code-scanning/1](https://github.com/Loyalsoldier/clash-rules/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged but still functional.

Best fix here: define workflow-level permissions directly under `on:` / before `jobs:` in `.github/workflows/run.yml`, since there is only one job and all steps share the same token needs. This preserves behavior while documenting security intent and preventing accidental broad access if repository defaults change.

For this workflow, required scopes are:
- `contents: write` (needed for release creation/upload and pushing to `release` branch)

No imports/dependencies/methods are needed; only YAML config update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
